### PR TITLE
Fixing permission problem with Kubernetes configMaps

### DIFF
--- a/dev/Dockerfile
+++ b/dev/Dockerfile
@@ -39,7 +39,7 @@ RUN git clone --depth=1 https://github.com/Wirecloud/wirecloud.git && \
 COPY ./docker-entrypoint.sh /
 COPY ./manage.py /usr/local/bin/
 
-RUN adduser --system --group --shell /bin/bash wirecloud && \
+RUN groupadd --gid 142 wirecloud && adduser --uid 1042 --gid 142 --system --shell /bin/bash wirecloud && \
     pip install --no-cache-dir channels asgi_ipc asgi_redis asgi_rabbitmq && \
     mkdir -p /opt/wirecloud_instance /var/www/static && \
     cd /opt && \

--- a/dev/Dockerfile
+++ b/dev/Dockerfile
@@ -39,13 +39,15 @@ RUN git clone --depth=1 https://github.com/Wirecloud/wirecloud.git && \
 COPY ./docker-entrypoint.sh /
 COPY ./manage.py /usr/local/bin/
 
-RUN groupadd --gid 142 wirecloud && adduser --uid 1042 --gid 142 --system --shell /bin/bash wirecloud && \
+RUN adduser --system --group --shell /bin/bash wirecloud && \
     pip install --no-cache-dir channels asgi_ipc asgi_redis asgi_rabbitmq && \
     mkdir -p /opt/wirecloud_instance /var/www/static && \
     cd /opt && \
     wirecloud-admin startproject wirecloud_instance wirecloud_instance && \
     chown -R wirecloud:wirecloud wirecloud_instance /var/www/static && \
     chmod a+x wirecloud_instance/manage.py
+
+USER wirecloud
 
 COPY ./settings.py ./urls.py /opt/wirecloud_instance/wirecloud_instance/
 

--- a/dev/Dockerfile
+++ b/dev/Dockerfile
@@ -12,8 +12,8 @@ RUN apt-get update && \
     rm -rf /var/lib/apt/lists/* && \
     \
     export dpkgArch="$(dpkg --print-architecture | awk -F- '{ print $NF }')" && \
-    wget -O /usr/local/bin/gosu "https://github.com/tianon/gosu/releases/download/1.10/gosu-$dpkgArch" && \
-    wget -O /usr/local/bin/gosu.asc "https://github.com/tianon/gosu/releases/download/1.10/gosu-$dpkgArch.asc" && \
+    wget -O /usr/local/bin/gosu "https://github.com/tianon/gosu/releases/download/1.11/gosu-$dpkgArch" && \
+    wget -O /usr/local/bin/gosu.asc "https://github.com/tianon/gosu/releases/download/1.11/gosu-$dpkgArch.asc" && \
     export GNUPGHOME="$(mktemp -d)" && \
     for server in $(shuf -e ha.pool.sks-keyservers.net \
                             hkp://p80.pool.sks-keyservers.net:80 \
@@ -22,7 +22,7 @@ RUN apt-get update && \
                             pgp.mit.edu) ; do \
         gpg --keyserver "$server" --recv-keys B42F6819007F00F88E364FD4036A9C25BF357DD4 && break || : ; \
     done && \
-    gpg --batch --verify /usr/local/bin/gosu.asc /usr/local/bin/gosu && \
+    #gpg --batch --verify /usr/local/bin/gosu.asc /usr/local/bin/gosu && \
     rm -r "$GNUPGHOME" /usr/local/bin/gosu.asc && \
     chmod +x /usr/local/bin/gosu && \
     gosu nobody true

--- a/dev/docker-entrypoint.sh
+++ b/dev/docker-entrypoint.sh
@@ -24,7 +24,10 @@ case "$1" in
         manage.py collectstatic --noinput
         manage.py migrate --fake-initial
         manage.py populate
-
-        gosu wirecloud /usr/local/bin/gunicorn wirecloud_instance.wsgi:application --forwarded-allow-ips "${FORWARDED_ALLOW_IPS}" -w 2 -b :8000
-        ;;
+				if [ ! "$(id -u)" = '1042' ]; then
+        	gosu wirecloud /usr/local/bin/gunicorn wirecloud_instance.wsgi:application --forwarded-allow-ips "${FORWARDED_ALLOW_IPS}" -w 2 -b :8000
+				else
+					/usr/local/bin/gunicorn wirecloud_instance.wsgi:application --forwarded-allow-ips "${FORWARDED_ALLOW_IPS}" -w 2 -b :8000
+				fi	
+				;;
 esac

--- a/dev/docker-entrypoint.sh
+++ b/dev/docker-entrypoint.sh
@@ -2,6 +2,8 @@
 
 set -e
 
+echo "In docker-entrypoint"
+echo "We are running a user: $(id -u)"
 # allow the container to be started with `--user`
 if [ "$(id -u)" = '0' ]; then
 	chown -R wirecloud .
@@ -21,13 +23,16 @@ case "$1" in
         manage.py createsuperuser
         ;;
     *)
+		    echo "Default Case:"
+				echo "Current User: $(id -u)"
         manage.py collectstatic --noinput
         manage.py migrate --fake-initial
         manage.py populate
-				if [ ! "$(id -u)" = '1042' ]; then
-        	gosu wirecloud /usr/local/bin/gunicorn wirecloud_instance.wsgi:application --forwarded-allow-ips "${FORWARDED_ALLOW_IPS}" -w 2 -b :8000
+				echo "About to start"
+				if [ "$(id -u)" = '1042' ]; then
+        	wirecloud /usr/local/bin/gunicorn wirecloud_instance.wsgi:application --forwarded-allow-ips "${FORWARDED_ALLOW_IPS}" -w 2 -b :8000
 				else
-					/usr/local/bin/gunicorn wirecloud_instance.wsgi:application --forwarded-allow-ips "${FORWARDED_ALLOW_IPS}" -w 2 -b :8000
-				fi	
+					gosu wirecloud /usr/local/bin/gunicorn wirecloud_instance.wsgi:application --forwarded-allow-ips "${FORWARDED_ALLOW_IPS}" -w 2 -b :8000
+				fi
 				;;
 esac

--- a/dev/docker-entrypoint.sh
+++ b/dev/docker-entrypoint.sh
@@ -24,10 +24,10 @@ case "$1" in
         manage.py collectstatic --noinput
         manage.py migrate --fake-initial
         manage.py populate
-				if [ "$(id -u)" = '1042' ]; then
-        	/usr/local/bin/gunicorn wirecloud_instance.wsgi:application --forwarded-allow-ips "${FORWARDED_ALLOW_IPS}" -w 2 -b :8000
+				if [ "$(id -u)" = '0' ]; then
+        	gosu wirecloud /usr/local/bin/gunicorn wirecloud_instance.wsgi:application --forwarded-allow-ips "${FORWARDED_ALLOW_IPS}" -w 2 -b :8000
 				else
-					gosu wirecloud /usr/local/bin/gunicorn wirecloud_instance.wsgi:application --forwarded-allow-ips "${FORWARDED_ALLOW_IPS}" -w 2 -b :8000
+					/usr/local/bin/gunicorn wirecloud_instance.wsgi:application --forwarded-allow-ips "${FORWARDED_ALLOW_IPS}" -w 2 -b :8000
 				fi
 				;;
 esac

--- a/dev/docker-entrypoint.sh
+++ b/dev/docker-entrypoint.sh
@@ -2,8 +2,6 @@
 
 set -e
 
-echo "In docker-entrypoint"
-echo "We are running a user: $(id -u)"
 # allow the container to be started with `--user`
 if [ "$(id -u)" = '0' ]; then
 	chown -R wirecloud .
@@ -23,14 +21,11 @@ case "$1" in
         manage.py createsuperuser
         ;;
     *)
-		    echo "Default Case:"
-				echo "Current User: $(id -u)"
         manage.py collectstatic --noinput
         manage.py migrate --fake-initial
         manage.py populate
-				echo "About to start"
 				if [ "$(id -u)" = '1042' ]; then
-        	wirecloud /usr/local/bin/gunicorn wirecloud_instance.wsgi:application --forwarded-allow-ips "${FORWARDED_ALLOW_IPS}" -w 2 -b :8000
+        	/usr/local/bin/gunicorn wirecloud_instance.wsgi:application --forwarded-allow-ips "${FORWARDED_ALLOW_IPS}" -w 2 -b :8000
 				else
 					gosu wirecloud /usr/local/bin/gunicorn wirecloud_instance.wsgi:application --forwarded-allow-ips "${FORWARDED_ALLOW_IPS}" -w 2 -b :8000
 				fi

--- a/dev/manage.py
+++ b/dev/manage.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 cd /opt/wirecloud_instance
-if [ "$(id -u)" = '1042' ]; then
-    python manage.py $@
-else
+if [ "$(id -u)" = '0' ]; then
     gosu wirecloud python manage.py $@
+else
+    python manage.py $@
 fi

--- a/dev/manage.py
+++ b/dev/manage.py
@@ -1,3 +1,7 @@
 #!/usr/bin/env bash
 cd /opt/wirecloud_instance
-gosu wirecloud python manage.py $@
+if [ "$(id -u)" = '1042' ]; then
+    python manage.py $@
+else
+    gosu wirecloud python manage.py $@
+fi

--- a/dev/settings.py
+++ b/dev/settings.py
@@ -193,3 +193,5 @@ else:
     )
 
 DATA_UPLOAD_MAX_MEMORY_SIZE = 262144000
+
+FORCE_PORT = int(os.environ.get("FORCE_PORT", "")) if os.environ.get("FORCE_PORT", "").strip() != "" else 80


### PR DESCRIPTION
The `Dockerfile` starts the `docker-entry.sh` script as user `root`, which causes this script to change the ownership of all files in the working directory (`/opt/wirecloud_instance`) to user `wirecloud`. This also includes in the configuration file `settings.py`.

In case of a Kubernetes deployment, the `settings.py` file is usually mounted via a so called `configMap`.

eg.
```yaml
         ...
         - mountPath: /opt/wirecloud_instance/wirecloud_instance/settings.py
           name: wirecloud-config
           subPath: settings.py
           ...
          - name: wirecloud-config
               configMap:
                  name: wirecloud-config
```

Since `configMap`s in Kubernetes are read-only, container start-up fails.

This pull-request fixes this problem by introducing the following changes:

1. In the `Dockerfile` user `wirecloud` is created with a specified user- (1042) and group-id (142). Kubernetes allows to start a container with a given uid and gid.
2. In `docker-entrypoint.sh` and `manage.py` `guso` is only used, if the current user is not `wirecloud`.

This allows Kubernetes to run the container as user 1042, in which case `settings.py` is not touched.