### PR TITLE
Allow to use custom configuration files

### DIFF
--- a/1.2/docker-compose-config-file.yml
+++ b/1.2/docker-compose-config-file.yml
@@ -1,0 +1,62 @@
+version: "3"
+
+services:
+
+    nginx:
+        restart: always
+        image: nginx:latest
+        ports:
+            - 80:80
+        volumes:
+            - ./nginx.conf:/etc/nginx/nginx.conf:ro
+            - ./wirecloud-static:/var/www/static:ro
+        depends_on:
+            - wirecloud
+
+
+    postgres:
+        restart: always
+        image: postgres:latest
+        environment:
+            - POSTGRES_PASSWORD=wirepass   # Change this password!
+        volumes:
+            - ./postgres-data:/var/lib/postgresql/data
+
+
+    elasticsearch:
+        restart: always
+        image: elasticsearch:2.4
+        volumes:
+            - ./elasticsearch-data:/usr/share/elasticsearch/data
+        command: elasticsearch -Des.index.max_result_window=50000
+
+
+    memcached:
+        restart: always
+        image: memcached:1
+        command: memcached -m 2048m
+
+
+    wirecloud:
+        restart: always
+        image: fiware/wirecloud:1.2
+        depends_on:
+            - postgres
+            - elasticsearch
+            - memcached
+        environment:
+            - DEBUG=False
+            # - DEFAULT_THEME=wirecloud.defaulttheme
+            - DB_HOST=postgres
+            - DB_PASSWORD=wirepass   # Change this password!
+            - FORWARDED_ALLOW_IPS=*
+            - ELASTICSEARCH2_URL=http://elasticsearch:9200/
+            - MEMCACHED_LOCATION=memcached:11211
+            # Uncomment the following environment variables to enable IDM integration
+            #- FIWARE_IDM_SERVER=${FIWARE_IDM_SERVER}
+            #- SOCIAL_AUTH_FIWARE_KEY=${SOCIAL_AUTH_FIWARE_KEY}
+            #- SOCIAL_AUTH_FIWARE_SECRET=${SOCIAL_AUTH_FIWARE_SECRET}
+        volumes:
+            - ./wirecloud-data:/opt/wirecloud_instance/data
+            - ./wirecloud-static:/var/www/static
+            - ./settings.py:/opt/wirecloud_instance/wirecloud_instance/settings.py:ro

--- a/1.2/docker-entrypoint.sh
+++ b/1.2/docker-entrypoint.sh
@@ -4,7 +4,7 @@ set -e
 
 # allow the container to be started with `--user`
 if [ "$(id -u)" = '0' ]; then
-	chown -R wirecloud .
+	chown -R wirecloud data
 	chown -R wirecloud /var/www/static
 fi
 

--- a/dev/docker-compose-config-file.yml
+++ b/dev/docker-compose-config-file.yml
@@ -1,0 +1,62 @@
+version: "3"
+
+services:
+
+    nginx:
+        restart: always
+        image: nginx:latest
+        ports:
+            - 80:80
+        volumes:
+            - ./nginx.conf:/etc/nginx/nginx.conf:ro
+            - ./wirecloud-static:/var/www/static:ro
+        depends_on:
+            - wirecloud
+
+
+    postgres:
+        restart: always
+        image: postgres:latest
+        environment:
+            - POSTGRES_PASSWORD=wirepass   # Change this password!
+        volumes:
+            - ./postgres-data:/var/lib/postgresql/data
+
+
+    elasticsearch:
+        restart: always
+        image: elasticsearch:2.4
+        volumes:
+            - ./elasticsearch-data:/usr/share/elasticsearch/data
+        command: elasticsearch -Des.index.max_result_window=50000
+
+
+    memcached:
+        restart: always
+        image: memcached:1
+        command: memcached -m 2048m
+
+
+    wirecloud:
+        restart: always
+        image: fiware/wirecloud:dev
+        depends_on:
+            - postgres
+            - elasticsearch
+            - memcached
+        environment:
+            - DEBUG=False
+            # - DEFAULT_THEME=wirecloud.defaulttheme
+            - DB_HOST=postgres
+            - DB_PASSWORD=wirepass   # Change this password!
+            - FORWARDED_ALLOW_IPS=*
+            - ELASTICSEARCH2_URL=http://elasticsearch:9200/
+            - MEMCACHED_LOCATION=memcached:11211
+            # Uncomment the following environment variables to enable IDM integration
+            #- FIWARE_IDM_SERVER=${FIWARE_IDM_SERVER}
+            #- SOCIAL_AUTH_FIWARE_KEY=${SOCIAL_AUTH_FIWARE_KEY}
+            #- SOCIAL_AUTH_FIWARE_SECRET=${SOCIAL_AUTH_FIWARE_SECRET}
+        volumes:
+            - ./wirecloud-data:/opt/wirecloud_instance/data
+            - ./wirecloud-static:/var/www/static
+            - ./settings.py:/opt/wirecloud_instance/wirecloud_instance/settings.py:ro

--- a/dev/docker-entrypoint.sh
+++ b/dev/docker-entrypoint.sh
@@ -4,7 +4,7 @@ set -e
 
 # allow the container to be started with `--user`
 if [ "$(id -u)" = '0' ]; then
-	chown -R wirecloud .
+	chown -R wirecloud data
 	chown -R wirecloud /var/www/static
 fi
 

--- a/dev/tests.py
+++ b/dev/tests.py
@@ -12,6 +12,30 @@ from urllib.parse import parse_qs, urlparse
 import requests
 import sh
 
+POLL_FREQUENCY = 0.5  # How long to sleep inbetween calls to the method
+
+
+class TimeoutException(Exception):
+    """
+    Thrown when a command does not complete in enough time.
+    """
+    pass
+
+
+def wait_until_running(timeout=120):
+    end_time = time.time() + timeout
+    while True:
+        try:
+            response = requests.get("http://localhost/api/version")
+            if response.status_code != 502:
+                return
+        except requests.exceptions.ConnectionError:
+            pass
+        time.sleep(POLL_FREQUENCY)
+        if time.time() > end_time:
+            break
+    raise TimeoutException()
+
 
 class WireCloudTests(object):
 
@@ -48,11 +72,12 @@ class StandaloneTests(unittest.TestCase, WireCloudTests):
 
     @classmethod
     def setUpClass(cls):
+        print("\n################################################################################\n")
         print("#")
         print("# Initializing standalone test case")
         print("#\n")
         sh.docker_compose("-f", "docker-compose-standalone.yml", "up", d=True, remove_orphans=True, _fg=True)
-        time.sleep(40)
+        wait_until_running()
         print()
 
     @classmethod
@@ -71,11 +96,12 @@ class SimpleTests(unittest.TestCase, WireCloudTests):
 
     @classmethod
     def setUpClass(cls):
+        print("\n################################################################################\n")
         print("#")
         print("# Initializing simple test case")
         print("#\n")
         sh.docker_compose("-f", "docker-compose-simple.yml", "up", d=True, remove_orphans=True, _fg=True)
-        time.sleep(40)
+        wait_until_running()
         print()
 
     @classmethod
@@ -94,11 +120,39 @@ class ComposedTests(unittest.TestCase, WireCloudTests):
 
     @classmethod
     def setUpClass(cls):
+        print("\n################################################################################\n")
         print("#")
         print("# Initializing composed test case")
         print("#\n")
         sh.docker_compose.up(d=True, remove_orphans=True, _fg=True)
-        time.sleep(40)
+        wait_until_running()
+        print()
+
+    @classmethod
+    def tearDownClass(cls):
+        print()
+        print("#")
+        print("# Removing containers and volumes")
+        print("#\n")
+        sh.docker_compose.down(remove_orphans=True, v=True, _fg=True)
+        shutil.rmtree('wirecloud-data')
+        shutil.rmtree('wirecloud-static')
+        shutil.rmtree('elasticsearch-data')
+        shutil.rmtree('postgres-data')
+        print()
+
+
+class ReadOnlyConfigTests(unittest.TestCase, WireCloudTests):
+
+    @classmethod
+    def setUpClass(cls):
+        print("\n################################################################################\n")
+        print("#")
+        print("# Initializing read-only config test case")
+        print("#\n")
+
+        sh.docker_compose("-f", "docker-compose-config-file.yml", "up", d=True, remove_orphans=True, _fg=True)
+        wait_until_running()
         print()
 
     @classmethod
@@ -119,6 +173,7 @@ class IDMTests(unittest.TestCase, WireCloudTests):
 
     @classmethod
     def setUpClass(cls):
+        print("\n################################################################################\n")
         print("#")
         print("# Initializing idm test case")
         print("#\n")
@@ -129,7 +184,7 @@ class IDMTests(unittest.TestCase, WireCloudTests):
         env["SOCIAL_AUTH_FIWARE_KEY"] = "wirecloud_test_client_id"
         env["SOCIAL_AUTH_FIWARE_SECRET"] = "notused"
         sh.docker_compose("-f", "docker-compose-idm.yml", "up", d=True, remove_orphans=True, _env=env, _fg=True)
-        time.sleep(45)
+        wait_until_running()
         print()
 
     @classmethod


### PR DESCRIPTION
This PR makes possible to use a custom `settings.py` file instead of configuring the image using environment variables. This is required to be able to configure any of the available settings from Django, for example.

This PR add tests for this feature using a read-only volume, but the behaviour is the same when using Docker's «config». Tests has been created this way because docker-compose does not support Docker's configs.