### PR TITLE
Fix gosu errors regarding gpg key management

### DIFF
--- a/1.0-composable/Dockerfile
+++ b/1.0-composable/Dockerfile
@@ -18,7 +18,7 @@ RUN apt update && \
                             keyserver.ubuntu.com \
                             hkp://keyserver.ubuntu.com:80 \
                             pgp.mit.edu) ; do \
-        gpg --keyserver "$server" --recv-keys B42F6819007F00F88E364FD4036A9C25BF357DD4 && break || : ; \
+        gpg --batch --keyserver "$server" --recv-keys B42F6819007F00F88E364FD4036A9C25BF357DD4 && break || : ; \
     done && \
     gpg --batch --verify /usr/local/bin/gosu.asc /usr/local/bin/gosu && \
     rm -r "$GNUPGHOME" /usr/local/bin/gosu.asc && \

--- a/1.1-composable/Dockerfile
+++ b/1.1-composable/Dockerfile
@@ -18,7 +18,7 @@ RUN apt update && \
                             keyserver.ubuntu.com \
                             hkp://keyserver.ubuntu.com:80 \
                             pgp.mit.edu) ; do \
-        gpg --keyserver "$server" --recv-keys B42F6819007F00F88E364FD4036A9C25BF357DD4 && break || : ; \
+        gpg --batch --keyserver "$server" --recv-keys B42F6819007F00F88E364FD4036A9C25BF357DD4 && break || : ; \
     done && \
     gpg --batch --verify /usr/local/bin/gosu.asc /usr/local/bin/gosu && \
     rm -r "$GNUPGHOME" /usr/local/bin/gosu.asc && \

--- a/1.2/Dockerfile
+++ b/1.2/Dockerfile
@@ -21,7 +21,7 @@ RUN apt-get update && \
                             keyserver.ubuntu.com \
                             hkp://keyserver.ubuntu.com:80 \
                             pgp.mit.edu) ; do \
-        gpg --keyserver "$server" --recv-keys B42F6819007F00F88E364FD4036A9C25BF357DD4 && break || : ; \
+        gpg --batch --keyserver "$server" --recv-keys B42F6819007F00F88E364FD4036A9C25BF357DD4 && break || : ; \
     done && \
     gpg --batch --verify /usr/local/bin/gosu.asc /usr/local/bin/gosu && \
     rm -r "$GNUPGHOME" /usr/local/bin/gosu.asc && \

--- a/dev/Dockerfile
+++ b/dev/Dockerfile
@@ -20,7 +20,7 @@ RUN apt-get update && \
                             keyserver.ubuntu.com \
                             hkp://keyserver.ubuntu.com:80 \
                             pgp.mit.edu) ; do \
-        gpg --keyserver "$server" --recv-keys B42F6819007F00F88E364FD4036A9C25BF357DD4 && break || : ; \
+        gpg --batch --keyserver "$server" --recv-keys B42F6819007F00F88E364FD4036A9C25BF357DD4 && break || : ; \
     done && \
     gpg --batch --verify /usr/local/bin/gosu.asc /usr/local/bin/gosu && \
     rm -r "$GNUPGHOME" /usr/local/bin/gosu.asc && \


### PR DESCRIPTION
Currently, docker image building is failing due gpg errors:
```
gpg: cannot open '/dev/tty': No such device or address
```

This is a problem in gpg and it is currently tracked and is in the process to be fixed: https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=913614#27. So this will be fixed as soon as a new image is uploaded, but from one of the comments:

> PS i do encourage everyone who is automating the use of gpg to use --batch everywhere, as this forces GnuPG into a mode that is expected to be used for automation (its "API", for lack of a better term, as opposed to its "UI", which is its normal non-batch mode). And, FWIW, I agree with Tianon that GnuPG should simply assume --batch if no tty exists, but that's not the kind of change i can fit into debian stable, i think.