### PR TITLE
Fix missing translations on the dev image

### DIFF
--- a/1.0-composable/tests.py
+++ b/1.0-composable/tests.py
@@ -56,6 +56,14 @@ class ComposedTests(unittest.TestCase):
         response = requests.get("http://localhost/static/theme/wirecloud.defaulttheme/images/logos/header.png")
         self.assertEqual(response.status_code, 200)
 
+    def test_should_serve_translations(self):
+        response = requests.get("http://localhost/api/i18n/js_catalogue?language=es")
+        self.assertEqual(response.status_code, 200)
+        # Look for basic translations
+        self.assertIn('"Yes"', response.text)
+        self.assertIn('"No"', response.text)
+        self.assertIn('"Warning"', response.text)
+
 
 if __name__ == "__main__":
     unittest.main(verbosity=2)

--- a/1.1-composable/tests.py
+++ b/1.1-composable/tests.py
@@ -56,6 +56,14 @@ class ComposedTests(unittest.TestCase):
         response = requests.get("http://localhost/static/theme/wirecloud.defaulttheme/images/logos/header.png")
         self.assertEqual(response.status_code, 200)
 
+    def test_should_serve_translations(self):
+        response = requests.get("http://localhost/api/i18n/js_catalogue?language=es")
+        self.assertEqual(response.status_code, 200)
+        # Look for basic translations
+        self.assertIn('"Yes"', response.text)
+        self.assertIn('"No"', response.text)
+        self.assertIn('"Warning"', response.text)
+
 
 if __name__ == "__main__":
     unittest.main(verbosity=2)

--- a/1.2/tests.py
+++ b/1.2/tests.py
@@ -35,6 +35,14 @@ class WireCloudTests(object):
         response = requests.get("http://localhost/static/theme/wirecloud.defaulttheme/images/logos/header.png")
         self.assertEqual(response.status_code, 200)
 
+    def test_should_serve_translations(self):
+        response = requests.get("http://localhost/api/i18n/js_catalogue?language=es")
+        self.assertEqual(response.status_code, 200)
+        # Look for basic translations
+        self.assertIn('"Yes"', response.text)
+        self.assertIn('"No"', response.text)
+        self.assertIn('"Warning"', response.text)
+
 
 class StandaloneTests(unittest.TestCase, WireCloudTests):
 

--- a/dev/Dockerfile
+++ b/dev/Dockerfile
@@ -29,12 +29,15 @@ RUN apt-get update && \
 
 # Install WireCloud & dependencies
 RUN git clone --depth=1 https://github.com/Wirecloud/wirecloud.git && \
+    apt-get update && apt-get install -y gettext && \
     pip install "django<=1.11" && \
     cd wirecloud/src && \
     python setup.py bdist_wheel && \
     pip install --no-cache-dir dist/*.whl && \
     cd ../.. && \
-    rm -rf wirecloud
+    rm -rf wirecloud && \
+    apt-get remove -y gettext && \
+    rm -rf /var/lib/apt/lists/*
 
 COPY ./docker-entrypoint.sh /
 COPY ./manage.py /usr/local/bin/

--- a/dev/tests.py
+++ b/dev/tests.py
@@ -35,6 +35,14 @@ class WireCloudTests(object):
         response = requests.get("http://localhost/static/theme/wirecloud.defaulttheme/images/logos/header.png")
         self.assertEqual(response.status_code, 200)
 
+    def test_should_serve_translations(self):
+        response = requests.get("http://localhost/api/i18n/js_catalogue?language=es")
+        self.assertEqual(response.status_code, 200)
+        # Look for basic translations
+        self.assertIn('"Yes"', response.text)
+        self.assertIn('"No"', response.text)
+        self.assertIn('"Warning"', response.text)
+
 
 class StandaloneTests(unittest.TestCase, WireCloudTests):
 


### PR DESCRIPTION
Dev image is missing translations as gettext is not installed (so translation compilation is failing). This PR fixes this by installing gettext. Also adds the required tests for ensuring translations are working on all the images.