### PR TITLE
Allow to execute WireCloud image using a custom user

### DIFF
--- a/1.2/docker-compose-custom-user.yml
+++ b/1.2/docker-compose-custom-user.yml
@@ -1,0 +1,17 @@
+version: "3"
+
+services:
+
+    wirecloud:
+        restart: always
+        image: fiware/wirecloud:1.2
+        # If you want to use a user from the host, provide here the id of the
+        # user, e.g. `export WIRECLOUD_USER=$(id -u username)`
+        user: ${WIRECLOUD_USER:-0}
+        ports:
+            - 80:8000
+        environment:
+            - DEBUG=True
+        volumes:
+            - ./wirecloud-data:/opt/wirecloud_instance/data
+            - ./wirecloud-static:/var/www/static

--- a/1.2/docker-entrypoint.sh
+++ b/1.2/docker-entrypoint.sh
@@ -25,6 +25,11 @@ case "$1" in
         manage.py migrate --fake-initial
         manage.py populate
 
-        gosu wirecloud /usr/local/bin/gunicorn wirecloud_instance.wsgi:application --forwarded-allow-ips "${FORWARDED_ALLOW_IPS}" -w 2 -b :8000
+        # allow the container to be started with `--user`
+        if [ "$(id -u)" = '0' ]; then
+            gosu wirecloud /usr/local/bin/gunicorn wirecloud_instance.wsgi:application --forwarded-allow-ips "${FORWARDED_ALLOW_IPS}" -w 2 -b :8000
+        else
+            /usr/local/bin/gunicorn wirecloud_instance.wsgi:application --forwarded-allow-ips "${FORWARDED_ALLOW_IPS}" -w 2 -b :8000
+        fi
         ;;
 esac

--- a/1.2/manage.py
+++ b/1.2/manage.py
@@ -1,3 +1,7 @@
 #!/usr/bin/env bash
 cd /opt/wirecloud_instance
-gosu wirecloud python manage.py $@
+if [ "$(id -u)" = '0' ]; then
+    gosu wirecloud python manage.py $@
+else
+    python manage.py $@
+fi

--- a/dev/docker-compose-custom-user.yml
+++ b/dev/docker-compose-custom-user.yml
@@ -1,0 +1,17 @@
+version: "3"
+
+services:
+
+    wirecloud:
+        restart: always
+        image: fiware/wirecloud:dev
+        # If you want to use a user from the host, provide here the id of the
+        # user, e.g. `export WIRECLOUD_USER=$(id -u username)`
+        user: ${WIRECLOUD_USER:-0}
+        ports:
+            - 80:8000
+        environment:
+            - DEBUG=True
+        volumes:
+            - ./wirecloud-data:/opt/wirecloud_instance/data
+            - ./wirecloud-static:/var/www/static

--- a/dev/docker-entrypoint.sh
+++ b/dev/docker-entrypoint.sh
@@ -25,6 +25,11 @@ case "$1" in
         manage.py migrate --fake-initial
         manage.py populate
 
-        gosu wirecloud /usr/local/bin/gunicorn wirecloud_instance.wsgi:application --forwarded-allow-ips "${FORWARDED_ALLOW_IPS}" -w 2 -b :8000
+        # allow the container to be started with `--user`
+        if [ "$(id -u)" = '0' ]; then
+            gosu wirecloud /usr/local/bin/gunicorn wirecloud_instance.wsgi:application --forwarded-allow-ips "${FORWARDED_ALLOW_IPS}" -w 2 -b :8000
+        else
+            /usr/local/bin/gunicorn wirecloud_instance.wsgi:application --forwarded-allow-ips "${FORWARDED_ALLOW_IPS}" -w 2 -b :8000
+        fi
         ;;
 esac

--- a/dev/manage.py
+++ b/dev/manage.py
@@ -1,3 +1,7 @@
 #!/usr/bin/env bash
 cd /opt/wirecloud_instance
-gosu wirecloud python manage.py $@
+if [ "$(id -u)" = '0' ]; then
+    gosu wirecloud python manage.py $@
+else
+    python manage.py $@
+fi


### PR DESCRIPTION
This PR makes the needed changes to allow to run WireCloud image using a predefined user on the host system.

This user can be configured using the [`--user` flag](https://docs.docker.com/engine/reference/run/#user) when using `docker run` on the cli, the [user option](https://docs.docker.com/compose/compose-file/#domainname-hostname-ipc-mac_address-privileged-read_only-shm_size-stdin_open-tty-user-working_dir) on the docker-compose files, ...

This PR fixes, at least, part of the problem reported on PR #14. Would be great if @fiware-austria can review it as this PR was based on his researches.