### PR TITLE
Fix healtcheck script on dev

### DIFF
--- a/dev/Dockerfile
+++ b/dev/Dockerfile
@@ -58,7 +58,7 @@ VOLUME /opt/wirecloud_instance/data
 
 EXPOSE 8000
 
-HEALTHCHECK CMD --interval=3s \
+HEALTHCHECK --interval=3s \
 	CMD curl --fail http://localhost:8000/api/features || exit 1
 
 ENTRYPOINT ["/docker-entrypoint.sh"]


### PR DESCRIPTION
This PR fixes healthcheck script on the dev image. Currently it has an extra `CMD` that makes docker use an incorrect healtcheck script:

```
HEALTHCHECK CMD --interval=3s \
    CMD curl --fail http://localhost:8000/api/features || exit 1
````

The correct declaration is:

```
HEALTHCHECK --interval=3s \
    CMD curl --fail http://localhost:8000/api/features || exit 1
```