### PR TITLE
Support logging

### DIFF
--- a/1.2/Dockerfile
+++ b/1.2/Dockerfile
@@ -6,6 +6,7 @@ ENV DEFAULT_THEME=wirecloud.defaulttheme
 ENV FORWARDED_ALLOW_IPS=*
 ENV DB_HOST=
 ENV DB_PORT=5432
+ENV LOGLEVEL=info
 
 RUN apt-get update && \
     apt-get install -y libmemcached-dev gosu && \

--- a/1.2/docker-compose.yml
+++ b/1.2/docker-compose.yml
@@ -46,6 +46,7 @@ services:
             - memcached
         environment:
             - DEBUG=False
+            - LOGLEVEL=INFO
             # - DEFAULT_THEME=wirecloud.defaulttheme
             - DB_HOST=postgres
             - DB_PASSWORD=wirepass   # Change this password!

--- a/1.2/docker-entrypoint.sh
+++ b/1.2/docker-entrypoint.sh
@@ -27,9 +27,19 @@ case "$1" in
 
         # allow the container to be started with `--user`
         if [ "$(id -u)" = '0' ]; then
-            gosu wirecloud /usr/local/bin/gunicorn wirecloud_instance.wsgi:application --forwarded-allow-ips "${FORWARDED_ALLOW_IPS}" -w 2 -b :8000
+            exec gosu wirecloud /usr/local/bin/gunicorn wirecloud_instance.wsgi:application \
+                --forwarded-allow-ips "${FORWARDED_ALLOW_IPS}" \
+                --workers 2 \
+                --bind 0.0.0.0:8000 \
+                --log-file - \
+                --log-level ${LOGLEVEL}
         else
-            /usr/local/bin/gunicorn wirecloud_instance.wsgi:application --forwarded-allow-ips "${FORWARDED_ALLOW_IPS}" -w 2 -b :8000
+            exec /usr/local/bin/gunicorn wirecloud_instance.wsgi:application \
+                --forwarded-allow-ips "${FORWARDED_ALLOW_IPS}" \
+                --workers 2 \
+                --bind 0.0.0.0:8000 \
+                --log-file - \
+                --log-level ${LOGLEVEL}
         fi
         ;;
 esac

--- a/1.2/settings.py
+++ b/1.2/settings.py
@@ -193,3 +193,37 @@ else:
     )
 
 DATA_UPLOAD_MAX_MEMORY_SIZE = 262144000
+
+LOGGING = {
+    'version': 1,
+    'disable_existing_loggers': False,
+    'filters': {
+        'require_debug_false': {
+            '()': 'django.utils.log.RequireDebugFalse'
+        },
+        'skip_unreadable_posts': {
+            '()': 'wirecloud.commons.utils.log.SkipUnreadablePosts',
+        }
+    },
+    'handlers': {
+        'console': {
+            'level': 'INFO',
+            'class': 'logging.StreamHandler',
+        },
+        'mail_admins': {
+            'level': 'ERROR',
+            'filters': ['require_debug_false', 'skip_unreadable_posts'],
+            'class': 'django.utils.log.AdminEmailHandler'
+        }
+    },
+    'loggers': {
+        '': {
+            'handlers': ['console'],
+        },
+        'django.request': {
+            'handlers': ['console', 'mail_admins'],
+            'level': 'ERROR',
+            'propagate': False,
+        },
+    }
+}

--- a/README.md
+++ b/README.md
@@ -30,6 +30,7 @@ The following environment variables are also honored for configuring your WireCl
 
 - `-e DEBUG=...` (defaults to "False", use "True" for running WireCloud in debug
     mode. Debug mode should be enabled for running WireCloud in standalone mode)
+- `-e LOGLEVEL=...` (defaults to "INFO")
 - `-e ALLOWED_HOSTS=...` (defaults to "*", whitespace whitespace-separated list
     of allowed hosts. See [django documentation][ALLOWED_HOSTS] for more
     details)

--- a/dev/Dockerfile
+++ b/dev/Dockerfile
@@ -1,4 +1,3 @@
-
 ARG PYTHON_VERSION=3.6-stretch
 FROM python:${PYTHON_VERSION}
 
@@ -17,7 +16,8 @@ MAINTAINER WireCloud Team <wirecloud@conwet.com>
 
 ENV DEFAULT_THEME=wirecloud.defaulttheme \
     FORWARDED_ALLOW_IPS=* \
-    DB_PORT=5432 
+    DB_PORT=5432 \
+    LOGLEVEL=info
 
 RUN apt-get update && \
     apt-get install -y libmemcached-dev gosu && \

--- a/dev/docker-compose.yml
+++ b/dev/docker-compose.yml
@@ -46,6 +46,7 @@ services:
             - memcached
         environment:
             - DEBUG=False
+            - LOGLEVEL=INFO
             # - DEFAULT_THEME=wirecloud.defaulttheme
             - DB_HOST=postgres
             - DB_PASSWORD=wirepass   # Change this password!

--- a/dev/docker-entrypoint.sh
+++ b/dev/docker-entrypoint.sh
@@ -54,9 +54,19 @@ case "$1" in
 
         # allow the container to be started with `--user`
         if [ "$(id -u)" = '0' ]; then
-            gosu wirecloud /usr/local/bin/gunicorn wirecloud_instance.wsgi:application --forwarded-allow-ips "${FORWARDED_ALLOW_IPS}" -w 2 -b :8000
+            exec gosu wirecloud /usr/local/bin/gunicorn wirecloud_instance.wsgi:application \
+                --forwarded-allow-ips "${FORWARDED_ALLOW_IPS}" \
+                --workers 2 \
+                --bind 0.0.0.0:8000 \
+                --log-file - \
+                --log-level ${LOGLEVEL}
         else
-            /usr/local/bin/gunicorn wirecloud_instance.wsgi:application --forwarded-allow-ips "${FORWARDED_ALLOW_IPS}" -w 2 -b :8000
+            exec /usr/local/bin/gunicorn wirecloud_instance.wsgi:application \
+                --forwarded-allow-ips "${FORWARDED_ALLOW_IPS}" \
+                --workers 2 \
+                --bind 0.0.0.0:8000 \
+                --log-file - \
+                --log-level ${LOGLEVEL}
         fi
         ;;
 esac

--- a/dev/settings.py
+++ b/dev/settings.py
@@ -194,3 +194,37 @@ else:
     )
 
 DATA_UPLOAD_MAX_MEMORY_SIZE = 262144000
+
+LOGGING = {
+    'version': 1,
+    'disable_existing_loggers': False,
+    'filters': {
+        'require_debug_false': {
+            '()': 'django.utils.log.RequireDebugFalse'
+        },
+        'skip_unreadable_posts': {
+            '()': 'wirecloud.commons.utils.log.SkipUnreadablePosts',
+        }
+    },
+    'handlers': {
+        'console': {
+            'level': 'INFO',
+            'class': 'logging.StreamHandler',
+        },
+        'mail_admins': {
+            'level': 'ERROR',
+            'filters': ['require_debug_false', 'skip_unreadable_posts'],
+            'class': 'django.utils.log.AdminEmailHandler'
+        }
+    },
+    'loggers': {
+        '': {
+            'handlers': ['console'],
+        },
+        'django.request': {
+            'handlers': ['console', 'mail_admins'],
+            'level': 'ERROR',
+            'propagate': False,
+        },
+    }
+}


### PR DESCRIPTION
This PR changes WireCloud configuration so it provides logs through standard output and thus, those logs can be captured by docker.