### PR TITLE
Fix error when building WireCloud 1.3 docker images (close #47)

### DIFF
--- a/1.2/Dockerfile
+++ b/1.2/Dockerfile
@@ -21,7 +21,7 @@ COPY ./docker-entrypoint.sh /
 COPY ./manage.py /usr/local/bin/
 
 RUN adduser --system --group --shell /bin/bash wirecloud && \
-    pip install --no-cache-dir channels asgi_ipc asgi_redis asgi_rabbitmq && \
+    pip install --no-cache-dir "channels<2.4.0" asgi_ipc asgi_redis asgi_rabbitmq && \
     mkdir -p /opt/wirecloud_instance /var/www/static && \
     cd /opt && \
     wirecloud-admin startproject wirecloud_instance wirecloud_instance && \

--- a/1.3/Dockerfile
+++ b/1.3/Dockerfile
@@ -21,7 +21,7 @@ COPY ./docker-entrypoint.sh /
 COPY ./manage.py /usr/local/bin/
 
 RUN adduser --system --group --shell /bin/bash wirecloud && \
-    pip install --no-cache-dir channels asgi_ipc asgi_redis asgi_rabbitmq wirecloud_keycloak && \
+    pip install --no-cache-dir "channels<2.4.0" asgi_ipc asgi_redis asgi_rabbitmq wirecloud_keycloak && \
     mkdir -p /opt/wirecloud_instance /var/www/static && \
     cd /opt && \
     wirecloud-admin startproject wirecloud_instance wirecloud_instance && \


### PR DESCRIPTION
This PR limits the version of Django/channels to less than 2.4.0 and resolves issue #47. It would be great if you could review this PR.

Thank you.
