### PR TITLE
Use named volumes to work around some docker problems on Windows

### DIFF
--- a/1.2/docker-compose-config-file.yml
+++ b/1.2/docker-compose-config-file.yml
@@ -9,7 +9,7 @@ services:
             - 80:80
         volumes:
             - ./nginx.conf:/etc/nginx/nginx.conf:ro
-            - ./wirecloud-static:/var/www/static:ro
+            - wirecloud-static:/var/www/static:ro
         depends_on:
             - wirecloud
 
@@ -20,14 +20,14 @@ services:
         environment:
             - POSTGRES_PASSWORD=wirepass   # Change this password!
         volumes:
-            - ./postgres-data:/var/lib/postgresql/data
+            - postgres-data:/var/lib/postgresql/data
 
 
     elasticsearch:
         restart: always
         image: elasticsearch:2.4
         volumes:
-            - ./elasticsearch-data:/usr/share/elasticsearch/data
+            - elasticsearch-data:/usr/share/elasticsearch/data
         command: elasticsearch -Des.index.max_result_window=50000
 
 
@@ -57,6 +57,12 @@ services:
             #- SOCIAL_AUTH_FIWARE_KEY=${SOCIAL_AUTH_FIWARE_KEY}
             #- SOCIAL_AUTH_FIWARE_SECRET=${SOCIAL_AUTH_FIWARE_SECRET}
         volumes:
-            - ./wirecloud-data:/opt/wirecloud_instance/data
-            - ./wirecloud-static:/var/www/static
+            - wirecloud-data:/opt/wirecloud_instance/data
+            - wirecloud-static:/var/www/static
             - ./settings.py:/opt/wirecloud_instance/wirecloud_instance/settings.py:ro
+
+volumes:
+    elasticsearch-data:
+    postgres-data:
+    wirecloud-data:
+    wirecloud-static:

--- a/1.2/docker-compose-idm.yml
+++ b/1.2/docker-compose-idm.yml
@@ -9,7 +9,7 @@ services:
             - 80:80
         volumes:
             - ./nginx.conf:/etc/nginx/nginx.conf:ro
-            - ./wirecloud-static:/var/www/static:ro
+            - wirecloud-static:/var/www/static:ro
         depends_on:
             - wirecloud
 
@@ -20,14 +20,14 @@ services:
         environment:
             - POSTGRES_PASSWORD=wirepass   # Change this password!
         volumes:
-            - ./postgres-data:/var/lib/postgresql/data
+            - postgres-data:/var/lib/postgresql/data
 
 
     elasticsearch:
         restart: always
         image: elasticsearch:2.4
         volumes:
-            - ./elasticsearch-data:/usr/share/elasticsearch/data
+            - elasticsearch-data:/usr/share/elasticsearch/data
         command: elasticsearch -Des.index.max_result_window=50000
 
 
@@ -73,5 +73,11 @@ services:
             - SOCIAL_AUTH_FIWARE_KEY=${SOCIAL_AUTH_FIWARE_KEY}
             - SOCIAL_AUTH_FIWARE_SECRET=${SOCIAL_AUTH_FIWARE_SECRET}
         volumes:
-            - ./wirecloud-data:/opt/wirecloud_instance/data
-            - ./wirecloud-static:/var/www/static
+            - wirecloud-data:/opt/wirecloud_instance/data
+            - wirecloud-static:/var/www/static
+
+volumes:
+    elasticsearch-data:
+    postgres-data:
+    wirecloud-data:
+    wirecloud-static:

--- a/1.2/docker-compose-simple.yml
+++ b/1.2/docker-compose-simple.yml
@@ -9,7 +9,7 @@ services:
             - 80:80
         volumes:
             - ./nginx.conf:/etc/nginx/nginx.conf:ro
-            - ./wirecloud-static:/var/www/static:ro
+            - wirecloud-static:/var/www/static:ro
         depends_on:
             - wirecloud
 
@@ -21,5 +21,9 @@ services:
             - DEBUG=False
             - FORWARDED_ALLOW_IPS=*
         volumes:
-            - ./wirecloud-data:/opt/wirecloud_instance/data
-            - ./wirecloud-static:/var/www/static
+            - wirecloud-data:/opt/wirecloud_instance/data
+            - wirecloud-static:/var/www/static
+
+volumes:
+    wirecloud-data:
+    wirecloud-static:

--- a/1.2/docker-compose-standalone.yml
+++ b/1.2/docker-compose-standalone.yml
@@ -10,5 +10,9 @@ services:
         environment:
             - DEBUG=True
         volumes:
-            - ./wirecloud-data:/opt/wirecloud_instance/data
-            - ./wirecloud-static:/var/www/static
+            - wirecloud-data:/opt/wirecloud_instance/data
+            - wirecloud-static:/var/www/static
+
+volumes:
+    wirecloud-data:
+    wirecloud-static:

--- a/1.2/docker-compose.yml
+++ b/1.2/docker-compose.yml
@@ -9,7 +9,7 @@ services:
             - 80:80
         volumes:
             - ./nginx.conf:/etc/nginx/nginx.conf:ro
-            - ./wirecloud-static:/var/www/static:ro
+            - wirecloud-static:/var/www/static:ro
         depends_on:
             - wirecloud
 
@@ -20,14 +20,14 @@ services:
         environment:
             - POSTGRES_PASSWORD=wirepass   # Change this password!
         volumes:
-            - ./postgres-data:/var/lib/postgresql/data
+            - postgres-data:/var/lib/postgresql/data
 
 
     elasticsearch:
         restart: always
         image: elasticsearch:2.4
         volumes:
-            - ./elasticsearch-data:/usr/share/elasticsearch/data
+            - elasticsearch-data:/usr/share/elasticsearch/data
         command: elasticsearch -Des.index.max_result_window=50000
 
 
@@ -58,5 +58,11 @@ services:
             #- SOCIAL_AUTH_FIWARE_KEY=${SOCIAL_AUTH_FIWARE_KEY}
             #- SOCIAL_AUTH_FIWARE_SECRET=${SOCIAL_AUTH_FIWARE_SECRET}
         volumes:
-            - ./wirecloud-data:/opt/wirecloud_instance/data
-            - ./wirecloud-static:/var/www/static
+            - wirecloud-data:/opt/wirecloud_instance/data
+            - wirecloud-static:/var/www/static
+
+volumes:
+    elasticsearch-data:
+    postgres-data:
+    wirecloud-data:
+    wirecloud-static:

--- a/1.2/tests.py
+++ b/1.2/tests.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 
-# Copyright (c) 2018 Future Internet Consulting and Development Solutions S.L.
+# Copyright (c) 2018-2020 Future Internet Consulting and Development Solutions S.L.
 
 import grp
 import pwd
@@ -89,8 +89,6 @@ class StandaloneTests(unittest.TestCase, WireCloudTests):
         print("# Removing containers and volumes")
         print("#\n")
         sh.docker_compose.down(remove_orphans=True, v=True, _fg=True)
-        shutil.rmtree('wirecloud-data')
-        shutil.rmtree('wirecloud-static')
         print()
 
 
@@ -113,8 +111,6 @@ class SimpleTests(unittest.TestCase, WireCloudTests):
         print("# Removing containers and volumes")
         print("#\n")
         sh.docker_compose.down(remove_orphans=True, v=True, _fg=True)
-        shutil.rmtree('wirecloud-data')
-        shutil.rmtree('wirecloud-static')
         print()
 
 
@@ -137,10 +133,6 @@ class ComposedTests(unittest.TestCase, WireCloudTests):
         print("# Removing containers and volumes")
         print("#\n")
         sh.docker_compose.down(remove_orphans=True, v=True, _fg=True)
-        shutil.rmtree('wirecloud-data')
-        shutil.rmtree('wirecloud-static')
-        shutil.rmtree('elasticsearch-data')
-        shutil.rmtree('postgres-data')
         print()
 
 
@@ -164,10 +156,6 @@ class ReadOnlyConfigTests(unittest.TestCase, WireCloudTests):
         print("# Removing containers and volumes")
         print("#\n")
         sh.docker_compose.down(remove_orphans=True, v=True, _fg=True)
-        shutil.rmtree('wirecloud-data')
-        shutil.rmtree('wirecloud-static')
-        shutil.rmtree('elasticsearch-data')
-        shutil.rmtree('postgres-data')
         print()
 
 
@@ -196,10 +184,6 @@ class IDMTests(unittest.TestCase, WireCloudTests):
         print("# Removing containers and volumes")
         print("#\n")
         sh.docker_compose.down(remove_orphans=True, v=True, _fg=True)
-        shutil.rmtree('wirecloud-data')
-        shutil.rmtree('wirecloud-static')
-        shutil.rmtree('elasticsearch-data')
-        shutil.rmtree('postgres-data')
         print()
 
     def test_login_should_redirect_to_idm(self):

--- a/1.3/docker-compose-config-file.yml
+++ b/1.3/docker-compose-config-file.yml
@@ -9,7 +9,7 @@ services:
             - 80:80
         volumes:
             - ./nginx.conf:/etc/nginx/nginx.conf:ro
-            - ./wirecloud-static:/var/www/static:ro
+            - wirecloud-static:/var/www/static:ro
         depends_on:
             - wirecloud
 
@@ -20,14 +20,14 @@ services:
         environment:
             - POSTGRES_PASSWORD=wirepass   # Change this password!
         volumes:
-            - ./postgres-data:/var/lib/postgresql/data
+            - postgres-data:/var/lib/postgresql/data
 
 
     elasticsearch:
         restart: always
         image: elasticsearch:2.4
         volumes:
-            - ./elasticsearch-data:/usr/share/elasticsearch/data
+            - elasticsearch-data:/usr/share/elasticsearch/data
         command: elasticsearch -Des.index.max_result_window=50000
 
 
@@ -57,6 +57,12 @@ services:
             #- SOCIAL_AUTH_FIWARE_KEY=${SOCIAL_AUTH_FIWARE_KEY}
             #- SOCIAL_AUTH_FIWARE_SECRET=${SOCIAL_AUTH_FIWARE_SECRET}
         volumes:
-            - ./wirecloud-data:/opt/wirecloud_instance/data
-            - ./wirecloud-static:/var/www/static
+            - wirecloud-data:/opt/wirecloud_instance/data
+            - wirecloud-static:/var/www/static
             - ./settings.py:/opt/wirecloud_instance/wirecloud_instance/settings.py:ro
+
+volumes:
+    elasticsearch-data:
+    postgres-data:
+    wirecloud-data:
+    wirecloud-static:

--- a/1.3/docker-compose-idm.yml
+++ b/1.3/docker-compose-idm.yml
@@ -9,7 +9,7 @@ services:
             - 80:80
         volumes:
             - ./nginx.conf:/etc/nginx/nginx.conf:ro
-            - ./wirecloud-static:/var/www/static:ro
+            - wirecloud-static:/var/www/static:ro
         depends_on:
             - wirecloud
 
@@ -20,14 +20,14 @@ services:
         environment:
             - POSTGRES_PASSWORD=wirepass   # Change this password!
         volumes:
-            - ./postgres-data:/var/lib/postgresql/data
+            - postgres-data:/var/lib/postgresql/data
 
 
     elasticsearch:
         restart: always
         image: elasticsearch:2.4
         volumes:
-            - ./elasticsearch-data:/usr/share/elasticsearch/data
+            - elasticsearch-data:/usr/share/elasticsearch/data
         command: elasticsearch -Des.index.max_result_window=50000
 
 
@@ -73,5 +73,11 @@ services:
             - SOCIAL_AUTH_FIWARE_KEY=${SOCIAL_AUTH_FIWARE_KEY}
             - SOCIAL_AUTH_FIWARE_SECRET=${SOCIAL_AUTH_FIWARE_SECRET}
         volumes:
-            - ./wirecloud-data:/opt/wirecloud_instance/data
-            - ./wirecloud-static:/var/www/static
+            - wirecloud-data:/opt/wirecloud_instance/data
+            - wirecloud-static:/var/www/static
+
+volumes:
+    elasticsearch-data:
+    postgres-data:
+    wirecloud-data:
+    wirecloud-static:

--- a/1.3/docker-compose-simple.yml
+++ b/1.3/docker-compose-simple.yml
@@ -9,7 +9,7 @@ services:
             - 80:80
         volumes:
             - ./nginx.conf:/etc/nginx/nginx.conf:ro
-            - ./wirecloud-static:/var/www/static:ro
+            - wirecloud-static:/var/www/static:ro
         depends_on:
             - wirecloud
 
@@ -21,5 +21,9 @@ services:
             - DEBUG=False
             - FORWARDED_ALLOW_IPS=*
         volumes:
-            - ./wirecloud-data:/opt/wirecloud_instance/data
-            - ./wirecloud-static:/var/www/static
+            - wirecloud-data:/opt/wirecloud_instance/data
+            - wirecloud-static:/var/www/static
+
+volumes:
+    wirecloud-data:
+    wirecloud-static:

--- a/1.3/docker-compose-standalone.yml
+++ b/1.3/docker-compose-standalone.yml
@@ -10,5 +10,9 @@ services:
         environment:
             - DEBUG=True
         volumes:
-            - ./wirecloud-data:/opt/wirecloud_instance/data
-            - ./wirecloud-static:/var/www/static
+            - wirecloud-data:/opt/wirecloud_instance/data
+            - wirecloud-static:/var/www/static
+
+volumes:
+    wirecloud-data:
+    wirecloud-static:

--- a/1.3/docker-compose.yml
+++ b/1.3/docker-compose.yml
@@ -9,7 +9,7 @@ services:
             - 80:80
         volumes:
             - ./nginx.conf:/etc/nginx/nginx.conf:ro
-            - ./wirecloud-static:/var/www/static:ro
+            - wirecloud-static:/var/www/static:ro
         depends_on:
             - wirecloud
 
@@ -20,14 +20,14 @@ services:
         environment:
             - POSTGRES_PASSWORD=wirepass   # Change this password!
         volumes:
-            - ./postgres-data:/var/lib/postgresql/data
+            - postgres-data:/var/lib/postgresql/data
 
 
     elasticsearch:
         restart: always
         image: elasticsearch:2.4
         volumes:
-            - ./elasticsearch-data:/usr/share/elasticsearch/data
+            - elasticsearch-data:/usr/share/elasticsearch/data
         command: elasticsearch -Des.index.max_result_window=50000
 
 
@@ -65,5 +65,11 @@ services:
             #- SOCIAL_AUTH_KEYCLOAK_KEY=${SOCIAL_AUTH_KEYCLOAK_KEY}
             #- SOCIAL_AUTH_KEYCLOAK_SECRET=${SOCIAL_AUTH_KEYCLOAK_SECRET}
         volumes:
-            - ./wirecloud-data:/opt/wirecloud_instance/data
-            - ./wirecloud-static:/var/www/static
+            - wirecloud-data:/opt/wirecloud_instance/data
+            - wirecloud-static:/var/www/static
+
+volumes:
+    elasticsearch-data:
+    postgres-data:
+    wirecloud-data:
+    wirecloud-static:

--- a/1.3/tests.py
+++ b/1.3/tests.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 
-# Copyright (c) 2018 Future Internet Consulting and Development Solutions S.L.
+# Copyright (c) 2018-2020 Future Internet Consulting and Development Solutions S.L.
 
 import grp
 import pwd
@@ -89,8 +89,6 @@ class StandaloneTests(unittest.TestCase, WireCloudTests):
         print("# Removing containers and volumes")
         print("#\n")
         sh.docker_compose.down(remove_orphans=True, v=True, _fg=True)
-        shutil.rmtree('wirecloud-data')
-        shutil.rmtree('wirecloud-static')
         print()
 
 
@@ -113,8 +111,6 @@ class SimpleTests(unittest.TestCase, WireCloudTests):
         print("# Removing containers and volumes")
         print("#\n")
         sh.docker_compose.down(remove_orphans=True, v=True, _fg=True)
-        shutil.rmtree('wirecloud-data')
-        shutil.rmtree('wirecloud-static')
         print()
 
 
@@ -137,10 +133,6 @@ class ComposedTests(unittest.TestCase, WireCloudTests):
         print("# Removing containers and volumes")
         print("#\n")
         sh.docker_compose.down(remove_orphans=True, v=True, _fg=True)
-        shutil.rmtree('wirecloud-data')
-        shutil.rmtree('wirecloud-static')
-        shutil.rmtree('elasticsearch-data')
-        shutil.rmtree('postgres-data')
         print()
 
 
@@ -164,10 +156,6 @@ class ReadOnlyConfigTests(unittest.TestCase, WireCloudTests):
         print("# Removing containers and volumes")
         print("#\n")
         sh.docker_compose.down(remove_orphans=True, v=True, _fg=True)
-        shutil.rmtree('wirecloud-data')
-        shutil.rmtree('wirecloud-static')
-        shutil.rmtree('elasticsearch-data')
-        shutil.rmtree('postgres-data')
         print()
 
 
@@ -196,10 +184,6 @@ class IDMTests(unittest.TestCase, WireCloudTests):
         print("# Removing containers and volumes")
         print("#\n")
         sh.docker_compose.down(remove_orphans=True, v=True, _fg=True)
-        shutil.rmtree('wirecloud-data')
-        shutil.rmtree('wirecloud-static')
-        shutil.rmtree('elasticsearch-data')
-        shutil.rmtree('postgres-data')
         print()
 
     def test_login_should_redirect_to_idm(self):

--- a/dev/docker-compose-config-file.yml
+++ b/dev/docker-compose-config-file.yml
@@ -9,7 +9,7 @@ services:
             - 80:80
         volumes:
             - ./nginx.conf:/etc/nginx/nginx.conf:ro
-            - ./wirecloud-static:/var/www/static:ro
+            - wirecloud-static:/var/www/static:ro
         depends_on:
             - wirecloud
 
@@ -20,14 +20,14 @@ services:
         environment:
             - POSTGRES_PASSWORD=wirepass   # Change this password!
         volumes:
-            - ./postgres-data:/var/lib/postgresql/data
+            - postgres-data:/var/lib/postgresql/data
 
 
     elasticsearch:
         restart: always
         image: elasticsearch:2.4
         volumes:
-            - ./elasticsearch-data:/usr/share/elasticsearch/data
+            - elasticsearch-data:/usr/share/elasticsearch/data
         command: elasticsearch -Des.index.max_result_window=50000
 
 
@@ -57,6 +57,12 @@ services:
             #- SOCIAL_AUTH_FIWARE_KEY=${SOCIAL_AUTH_FIWARE_KEY}
             #- SOCIAL_AUTH_FIWARE_SECRET=${SOCIAL_AUTH_FIWARE_SECRET}
         volumes:
-            - ./wirecloud-data:/opt/wirecloud_instance/data
-            - ./wirecloud-static:/var/www/static
+            - wirecloud-data:/opt/wirecloud_instance/data
+            - wirecloud-static:/var/www/static
             - ./settings.py:/opt/wirecloud_instance/wirecloud_instance/settings.py:ro
+
+volumes:
+    elasticsearch-data:
+    postgres-data:
+    wirecloud-data:
+    wirecloud-static:

--- a/dev/docker-compose-idm.yml
+++ b/dev/docker-compose-idm.yml
@@ -9,7 +9,7 @@ services:
             - 80:80
         volumes:
             - ./nginx.conf:/etc/nginx/nginx.conf:ro
-            - ./wirecloud-static:/var/www/static:ro
+            - wirecloud-static:/var/www/static:ro
         depends_on:
             - wirecloud
 
@@ -20,14 +20,14 @@ services:
         environment:
             - POSTGRES_PASSWORD=wirepass   # Change this password!
         volumes:
-            - ./postgres-data:/var/lib/postgresql/data
+            - postgres-data:/var/lib/postgresql/data
 
 
     elasticsearch:
         restart: always
         image: elasticsearch:2.4
         volumes:
-            - ./elasticsearch-data:/usr/share/elasticsearch/data
+            - elasticsearch-data:/usr/share/elasticsearch/data
         command: elasticsearch -Des.index.max_result_window=50000
 
 
@@ -73,5 +73,11 @@ services:
             - SOCIAL_AUTH_FIWARE_KEY=${SOCIAL_AUTH_FIWARE_KEY}
             - SOCIAL_AUTH_FIWARE_SECRET=${SOCIAL_AUTH_FIWARE_SECRET}
         volumes:
-            - ./wirecloud-data:/opt/wirecloud_instance/data
-            - ./wirecloud-static:/var/www/static
+            - wirecloud-data:/opt/wirecloud_instance/data
+            - wirecloud-static:/var/www/static
+
+volumes:
+    elasticsearch-data:
+    postgres-data:
+    wirecloud-data:
+    wirecloud-static:

--- a/dev/docker-compose-simple.yml
+++ b/dev/docker-compose-simple.yml
@@ -9,7 +9,7 @@ services:
             - 80:80
         volumes:
             - ./nginx.conf:/etc/nginx/nginx.conf:ro
-            - ./wirecloud-static:/var/www/static:ro
+            - wirecloud-static:/var/www/static:ro
         depends_on:
             - wirecloud
 
@@ -21,5 +21,9 @@ services:
             - DEBUG=False
             - FORWARDED_ALLOW_IPS=*
         volumes:
-            - ./wirecloud-data:/opt/wirecloud_instance/data
-            - ./wirecloud-static:/var/www/static
+            - wirecloud-data:/opt/wirecloud_instance/data
+            - wirecloud-static:/var/www/static
+
+volumes:
+    wirecloud-data:
+    wirecloud-static:

--- a/dev/docker-compose-standalone.yml
+++ b/dev/docker-compose-standalone.yml
@@ -10,5 +10,9 @@ services:
         environment:
             - DEBUG=True
         volumes:
-            - ./wirecloud-data:/opt/wirecloud_instance/data
-            - ./wirecloud-static:/var/www/static
+            - wirecloud-data:/opt/wirecloud_instance/data
+            - wirecloud-static:/var/www/static
+
+volumes:
+    wirecloud-data:
+    wirecloud-static:

--- a/dev/docker-compose.yml
+++ b/dev/docker-compose.yml
@@ -9,7 +9,7 @@ services:
             - 80:80
         volumes:
             - ./nginx.conf:/etc/nginx/nginx.conf:ro
-            - ./wirecloud-static:/var/www/static:ro
+            - wirecloud-static:/var/www/static:ro
         depends_on:
             - wirecloud
 
@@ -20,14 +20,14 @@ services:
         environment:
             - POSTGRES_PASSWORD=wirepass   # Change this password!
         volumes:
-            - ./postgres-data:/var/lib/postgresql/data
+            - postgres-data:/var/lib/postgresql/data
 
 
     elasticsearch:
         restart: always
         image: elasticsearch:2.4
         volumes:
-            - ./elasticsearch-data:/usr/share/elasticsearch/data
+            - elasticsearch-data:/usr/share/elasticsearch/data
         command: elasticsearch -Des.index.max_result_window=50000
 
 
@@ -65,5 +65,11 @@ services:
             #- SOCIAL_AUTH_KEYCLOAK_KEY=${SOCIAL_AUTH_KEYCLOAK_KEY}
             #- SOCIAL_AUTH_KEYCLOAK_SECRET=${SOCIAL_AUTH_KEYCLOAK_SECRET}
         volumes:
-            - ./wirecloud-data:/opt/wirecloud_instance/data
-            - ./wirecloud-static:/var/www/static
+            - wirecloud-data:/opt/wirecloud_instance/data
+            - wirecloud-static:/var/www/static
+
+volumes:
+    elasticsearch-data:
+    postgres-data:
+    wirecloud-data:
+    wirecloud-static:

--- a/dev/tests.py
+++ b/dev/tests.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 
-# Copyright (c) 2018 Future Internet Consulting and Development Solutions S.L.
+# Copyright (c) 2018-2020 Future Internet Consulting and Development Solutions S.L.
 
 import grp
 import pwd
@@ -89,8 +89,6 @@ class StandaloneTests(unittest.TestCase, WireCloudTests):
         print("# Removing containers and volumes")
         print("#\n")
         sh.docker_compose.down(remove_orphans=True, v=True, _fg=True)
-        shutil.rmtree('wirecloud-data')
-        shutil.rmtree('wirecloud-static')
         print()
 
 
@@ -113,8 +111,6 @@ class SimpleTests(unittest.TestCase, WireCloudTests):
         print("# Removing containers and volumes")
         print("#\n")
         sh.docker_compose.down(remove_orphans=True, v=True, _fg=True)
-        shutil.rmtree('wirecloud-data')
-        shutil.rmtree('wirecloud-static')
         print()
 
 
@@ -137,10 +133,6 @@ class ComposedTests(unittest.TestCase, WireCloudTests):
         print("# Removing containers and volumes")
         print("#\n")
         sh.docker_compose.down(remove_orphans=True, v=True, _fg=True)
-        shutil.rmtree('wirecloud-data')
-        shutil.rmtree('wirecloud-static')
-        shutil.rmtree('elasticsearch-data')
-        shutil.rmtree('postgres-data')
         print()
 
 
@@ -164,10 +156,6 @@ class ReadOnlyConfigTests(unittest.TestCase, WireCloudTests):
         print("# Removing containers and volumes")
         print("#\n")
         sh.docker_compose.down(remove_orphans=True, v=True, _fg=True)
-        shutil.rmtree('wirecloud-data')
-        shutil.rmtree('wirecloud-static')
-        shutil.rmtree('elasticsearch-data')
-        shutil.rmtree('postgres-data')
         print()
 
 
@@ -196,10 +184,6 @@ class IDMTests(unittest.TestCase, WireCloudTests):
         print("# Removing containers and volumes")
         print("#\n")
         sh.docker_compose.down(remove_orphans=True, v=True, _fg=True)
-        shutil.rmtree('wirecloud-data')
-        shutil.rmtree('wirecloud-static')
-        shutil.rmtree('elasticsearch-data')
-        shutil.rmtree('postgres-data')
         print()
 
     def test_login_should_redirect_to_idm(self):


### PR DESCRIPTION
Use named volumes on the docker-compose files provided as example to work around some docker problems on Windows. See Wirecloud/wirecloud#449 and Wirecloud/wirecloud#450 for more details.