### PR TITLE
Allow to configure WIRECLOUD_HTTPS_VERIFY

### DIFF
--- a/1.3/settings.py
+++ b/1.3/settings.py
@@ -227,6 +227,10 @@ else:
         'haystack',
     )
 
+# HTTPS verification
+verify = os.environ.get("HTTPS_VERIFY", "/etc/ssl/certs/ca-certificates.crt").strip()
+WIRECLOUD_HTTPS_VERIFY = True if verify.lower() == "true" else False if verify.lower() == "false" else verify
+
 # Login/logout URLs
 LOGIN_URL = reverse_lazy('login')
 LOGOUT_URL = reverse_lazy('wirecloud.root')

--- a/README.md
+++ b/README.md
@@ -67,6 +67,8 @@ The following environment variables are also honored for configuring your WireCl
 - `-e KEYCLOAK_GLOBAL_ROLE=...` (default to "False")
 - `-e SOCIAL_AUTH_KEYCLOAK_KEY=...` (defaults to nothing)
 - `-e SOCIAL_AUTH_KEYCLOAK_SECRET=...` (defaults to nothing)
+- `-e HTTPS_VERIFY=...` (True, False or path to a certificate bundle, default to
+   "/etc/ssl/certs/ca-certificates.crt"
 
 In addition to those environment variables, this docker image also allows you to
 configure the following Django settings using environment variables with the

--- a/dev/settings.py
+++ b/dev/settings.py
@@ -202,6 +202,10 @@ for setting in BOOLEAN_SETTINGS:
         locals()[setting] = value.lower() == "true"
 
 
+# HTTPS verification
+verify = os.environ.get("HTTPS_VERIFY", "/etc/ssl/certs/ca-certificates.crt").strip()
+WIRECLOUD_HTTPS_VERIFY = True if verify.lower() == "true" else False if verify.lower() == "false" else verify
+
 # FIWARE & Keycloak configuration
 IDM_AUTH = 'fiware' if "FIWARE_IDM_SERVER" in locals() and "SOCIAL_AUTH_FIWARE_KEY" in locals() and "SOCIAL_AUTH_FIWARE_SECRET" in locals() else None
 IDM_AUTH = 'keycloak' if "KEYCLOAK_SERVER" in locals() and "KEYCLOAK_REALM" in locals() and "KEYCLOAK_KEY" in locals() and "SOCIAL_AUTH_KEYCLOAK_KEY" in locals() and "SOCIAL_AUTH_KEYCLOAK_SECRET" in locals() else IDM_AUTH


### PR DESCRIPTION
This PR adds support for changing the `WIRECLOUD_HTTPS_VERIFY` setting. This PR also changes the default value to "/etc/ssl/certs/ca-certificates.crt" to make WireCloud use the trusted CA bundle from the base OS instead of using the bundle provided by [`requests`](https://requests.readthedocs.io/en/master/).