### PR TITLE
Allow to configure administration path

### DIFF
--- a/1.3/urls.py
+++ b/1.3/urls.py
@@ -1,5 +1,7 @@
 # -*- coding: utf-8 -*-
 
+import os
+
 from django.conf import settings
 from django.conf.urls import include, url
 from django.contrib import admin
@@ -34,7 +36,7 @@ urlpatterns = (
     url(r'^admin/logout/?$', wc_auth.logout),
 
     # Admin interface
-    url(r'^admin/', include(admin.site.urls)),
+    url(os.environ.get("ADMIN_URL_PATH", r'^admin/'), include(admin.site.urls)),
 )
 
 if settings.IDM_AUTH is not None:

--- a/README.md
+++ b/README.md
@@ -68,7 +68,8 @@ The following environment variables are also honored for configuring your WireCl
 - `-e SOCIAL_AUTH_KEYCLOAK_KEY=...` (defaults to nothing)
 - `-e SOCIAL_AUTH_KEYCLOAK_SECRET=...` (defaults to nothing)
 - `-e HTTPS_VERIFY=...` (True, False or path to a certificate bundle, default to
-   "/etc/ssl/certs/ca-certificates.crt"
+   "/etc/ssl/certs/ca-certificates.crt")
+- `-e ADMIN_URL_PATH=...` (default to "^admin/", regexp for the administration path)
 
 In addition to those environment variables, this docker image also allows you to
 configure the following Django settings using environment variables with the

--- a/dev/urls.py
+++ b/dev/urls.py
@@ -1,5 +1,7 @@
 # -*- coding: utf-8 -*-
 
+import os
+
 from django.conf import settings
 from django.conf.urls import include, url
 from django.contrib import admin
@@ -34,7 +36,7 @@ urlpatterns = (
     url(r'^admin/logout/?$', wc_auth.logout),
 
     # Admin interface
-    url(r'^admin/', admin.site.urls),
+    url(os.environ.get("ADMIN_URL_PATH", r'^admin/'), admin.site.urls),
 )
 
 if settings.IDM_AUTH:


### PR DESCRIPTION
Allow to configure the url path to be used for the Django administration web. Defaults to `^admin/`