### PR TITLE
Fix port redirection on Nginx configuration

### DIFF
--- a/1.1-composable/nginx.conf
+++ b/1.1-composable/nginx.conf
@@ -40,7 +40,7 @@ http {
 
         location / {
             proxy_pass http://wirecloud:8000;
-            proxy_set_header Host $host;
+            proxy_set_header Host $host:$server_port;
             proxy_set_header X-Real-IP $remote_addr;
             proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
         }

--- a/1.2/nginx.conf
+++ b/1.2/nginx.conf
@@ -40,7 +40,7 @@ http {
 
         location / {
             proxy_pass http://wirecloud:8000;
-            proxy_set_header Host $host;
+            proxy_set_header Host $host:$server_port;
             proxy_set_header X-Real-IP $remote_addr;
             proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
         }

--- a/1.3/nginx.conf
+++ b/1.3/nginx.conf
@@ -40,7 +40,7 @@ http {
 
         location / {
             proxy_pass http://wirecloud:8000;
-            proxy_set_header Host $host;
+            proxy_set_header Host $host:$server_port;
             proxy_set_header X-Real-IP $remote_addr;
             proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
         }

--- a/dev/nginx.conf
+++ b/dev/nginx.conf
@@ -40,7 +40,7 @@ http {
 
         location / {
             proxy_pass http://wirecloud:8000;
-            proxy_set_header Host $host;
+            proxy_set_header Host $host:$server_port;
             proxy_set_header X-Real-IP $remote_addr;
             proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
         }

--- a/hub-docs/nginx.conf
+++ b/hub-docs/nginx.conf
@@ -40,7 +40,7 @@ http {
 
         location / {
             proxy_pass http://wirecloud:8000;
-            proxy_set_header Host $host;
+            proxy_set_header Host $host:$server_port;
             proxy_set_header X-Real-IP $remote_addr;
             proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
         }


### PR DESCRIPTION
This PR fixes Nginx configuration when deploying WireCloud using a different port than 80.

Thanks to @jenisov for reporting this problem (#53 for more details).