### PR TITLE
Fix admin role synchronization not working when using KeyRock due changes on the python social auth module

### DIFF
--- a/1.1-composable/Dockerfile
+++ b/1.1-composable/Dockerfile
@@ -10,7 +10,7 @@ RUN apt update && \
     rm -rf /var/lib/apt/lists/* && \
     gosu nobody true
 
-RUN pip install "wirecloud<1.2"
+RUN pip install "wirecloud<1.2" django-appconf==1.0.3
 
 RUN adduser --system --group --shell /bin/bash wirecloud && \
     pip install --no-cache-dir channels asgi_ipc asgi_redis && \

--- a/1.2/settings.py
+++ b/1.2/settings.py
@@ -200,6 +200,8 @@ else:
         'django.contrib.auth.backends.ModelBackend',
     )
 
+SOCIAL_AUTH_NO_DEFAULT_PROTECTED_USER_FIELDS = True
+SOCIAL_AUTH_PROTECTED_USER_FIELDS = ('username', 'id', 'pk', 'email', 'password', 'is_active')
 DATA_UPLOAD_MAX_MEMORY_SIZE = 262144000
 
 LOGGING = {

--- a/1.3/settings.py
+++ b/1.3/settings.py
@@ -290,6 +290,8 @@ else:
         'django.contrib.auth.backends.ModelBackend',
     )
 
+SOCIAL_AUTH_NO_DEFAULT_PROTECTED_USER_FIELDS = True
+SOCIAL_AUTH_PROTECTED_USER_FIELDS = ('username', 'id', 'pk', 'email', 'password', 'is_active')
 DATA_UPLOAD_MAX_MEMORY_SIZE = 262144000
 
 LOGGING = {

--- a/dev/settings.py
+++ b/dev/settings.py
@@ -289,6 +289,8 @@ else:
         'django.contrib.auth.backends.ModelBackend',
     )
 
+SOCIAL_AUTH_NO_DEFAULT_PROTECTED_USER_FIELDS = True
+SOCIAL_AUTH_PROTECTED_USER_FIELDS = ('username', 'id', 'pk', 'email', 'password', 'is_active')
 SOCIAL_AUTH_PIPELINE = (
     'social_core.pipeline.social_auth.social_details',
     'social_core.pipeline.social_auth.social_uid',


### PR DESCRIPTION
New versions of the python social auth module changes the default list of fields to be protected by default, disallowing auth backends to synchronize the superuser flag on django. This PR makes the required changes to allow this again.