### PR TITLE
Increase default healthcheck timeouts

### DIFF
--- a/1.1-composable/Dockerfile
+++ b/1.1-composable/Dockerfile
@@ -38,8 +38,8 @@ VOLUME /opt/wirecloud_instance
 
 EXPOSE 8000
 
-HEALTHCHECK --interval=3s \
-    --start-period=40s \
+HEALTHCHECK --interval=5s \
+    --start-period=120s \
 	CMD curl --fail http://localhost:8000/api/features || exit 1
 
 COPY ./docker-entrypoint.sh /

--- a/1.2/Dockerfile
+++ b/1.2/Dockerfile
@@ -38,8 +38,8 @@ VOLUME /opt/wirecloud_instance/data
 
 EXPOSE 8000
 
-HEALTHCHECK --interval=3s \
-    --start-period=40s \
+HEALTHCHECK --interval=5s \
+    --start-period=120s \
 	CMD curl --fail http://localhost:8000/api/features || exit 1
 
 ENTRYPOINT ["/docker-entrypoint.sh"]

--- a/1.3/Dockerfile
+++ b/1.3/Dockerfile
@@ -37,8 +37,8 @@ VOLUME /opt/wirecloud_instance/data
 
 EXPOSE 8000
 
-HEALTHCHECK --interval=3s \
-    --start-period=40s \
+HEALTHCHECK --interval=5s \
+    --start-period=120s \
 	CMD curl --fail http://localhost:8000/api/features || exit 1
 
 ENTRYPOINT ["/docker-entrypoint.sh"]

--- a/dev/Dockerfile
+++ b/dev/Dockerfile
@@ -68,8 +68,8 @@ VOLUME /opt/wirecloud_instance/data
 
 EXPOSE 8000
 
-HEALTHCHECK --interval=3s \
-    --start-period=40s \
+HEALTHCHECK --interval=5s \
+    --start-period=120s \
 	CMD curl --fail http://localhost:8000/api/features || exit 1
 
 ENTRYPOINT ["/docker-entrypoint.sh"]


### PR DESCRIPTION
This PR increase default healthcheck timeouts to fix WireCloud container being killed on some scenarios.