### PR TITLE
Install social-auth-app-django<5 when building WireCloud 1.2

### DIFF
--- a/1.2/Dockerfile
+++ b/1.2/Dockerfile
@@ -10,7 +10,7 @@ ENV LOGLEVEL=info
 
 RUN apt-get update && \
     apt-get install -y libmemcached-dev gosu && \
-    pip install --no-cache-dir social-auth-app-django "gunicorn==19.3.0" "psycopg2==2.6" pylibmc pysolr "elasticsearch==2.4.1" && \
+    pip install --no-cache-dir "social-auth-app-django<5.0.0" "gunicorn==19.3.0" "psycopg2==2.6" pylibmc pysolr "elasticsearch==2.4.1" && \
     rm -rf /var/lib/apt/lists/* && \
     gosu nobody true
 


### PR DESCRIPTION
This PR forces the installation of `social-auth-app-django` version 4.0.0 when building the WireCloud 1.2 image.